### PR TITLE
Fix parsing of ingredients list

### DIFF
--- a/classes/Recipe/IngredientList.php
+++ b/classes/Recipe/IngredientList.php
@@ -59,15 +59,15 @@ class IngredientList
 
         $html = [];
 
-        $html[] = '<div class="' . $ingredientGroupClass . '" markdown="1">';
-        
+        $html[] = '<div class="' . $ingredientGroupClass . '">';
+
         $lastItem = null;
 
         foreach ($this->items as $item) {
-            
+
             if ($item instanceof Ingredient) {
                 if ($lastItem !== static::ITEM_INGREDIENT) {
-                    $html[] = '<ul markdown="1">';
+                    $html[] = '<ul>';
                 }
                 $html[] = $item->html($yieldFactor);
                 $lastItem = static::ITEM_INGREDIENT;
@@ -75,14 +75,14 @@ class IngredientList
                 if ($lastItem === static::ITEM_INGREDIENT) {
                     $html[] = '</ul>';
                 }
-                
+
                 if ($lastItem !== null && strlen($item) > 0 && $item[0] === '#') {
                     $html[] = '</div>';
-                    $html[] = '<div class="' . $ingredientGroupClass . '" markdown="1">';
+                    $html[] = '<div class="' . $ingredientGroupClass . '">';
                 }
 
                 $html[] = (new Ingredient($this->page, null, null, $item))->format($yieldFactor);
-                
+
                 $lastItem = 'text';
             }
         }


### PR DESCRIPTION
ParsedownExtra has an issue with parsing text which contains html markup with `mardown="1"`. On the local machine everything works fine. But on the production server (Uberspace) parts of the ingredients list disappear. (https://github.com/erusev/parsedown-extra/issues/153)

```
- Foo
- Bar

- Second Foo
- Second Bar
```

The second list with `Second Foo` and `Second Bar` disappears after parsing the HTML markup of the plugin.

Removing the `markdown="1"` attributes from the nested tags solves the issue. `<li markdown="1">` is enough to parse the markdown of a list item.