### PR TITLE
Correctly resolve links to draft recipes/knowledge base terms.

### DIFF
--- a/snippets/recipes-gallery.php
+++ b/snippets/recipes-gallery.php
@@ -1,4 +1,4 @@
-<ul class="recipes-gallery">
+<ul class="recipes-gallery"<?php if($item->isDraft()) echo ' style="background: repeating-linear-gradient(-45deg, rgba(209, 100, 100, .2), rgba(209, 100, 100, .2) 5px, transparent 5px, transparent 10px);"'; ?>>
   <?php foreach($recipes as $item): ?>
     <li><a href="<?= $item->url() ?>"><?= $item->title()->html() ?></a></li>
   <?php endforeach ?>

--- a/tags/recipes-gallery.php
+++ b/tags/recipes-gallery.php
@@ -15,24 +15,29 @@ return [
     ],
     'html' => function ($tag) {
 
+        $site = $tag->site();
+        $user = $tag->kirby()->user();
         $parentPage = $tag->parent()->parent();
-        $recipesBase = ($parentPage->template()->name() === 'recipes') ? $parentPage->id() : site()->children()->filterBy('template', 'recipes')->first()->id();
-        $recipes = array_map('trim', explode(',',$tag->attr('recipes-gallery')));
-        $site = site();
 
+        $recipesBase = ($parentPage->template()->name() === 'recipes')
+            ? $parentPage
+            : $site->children()->filterBy('template', 'recipes')->first();
+
+        $recipes = array_map('trim', explode(',', $tag->attr('recipes-gallery')));
         $collection = [];
 
         foreach ($recipes as $recipe) {
+            $item = null;
 
-            if (strstr($recipe, '/')) {
+            if (strstr($recipe, '/') === true) {
                 // absolute path
-                $target = $recipe;
+                $item = $site->findPageOrDraft($recipe);
             } else {
                 // just the slug
-                $target = "{$recipesBase}/{$recipe}";
+                $item = $recipesBase->findPageOrDraft($recipe);
             }
 
-            if ($item = $site->find($target)) {
+            if ($item && ($user !== null || $item->isDraft() === false)) {
                 $collection[] = $item;
             }
         }


### PR DESCRIPTION
Links to draft articles are now treated differently. For logged-in users, these will get some visual highlight, for anonymous visitors, no links are generated at all. This help, when working on multiple articles simultaniously, but publishing them at different times.