### PR TITLE
Feature/pie calculator

### DIFF
--- a/blueprints/sections/recipe-content.yml
+++ b/blueprints/sections/recipe-content.yml
@@ -24,6 +24,45 @@ fields:
     type: text
     width: 1/3
     default: Portionen
+  type:
+    label: Rezepttyp
+    type: select
+    default: ""
+    options:
+      default: Standard
+      pie: Torte
+    width: 1/4
+    required: true
+  diameter:
+    label: Durchmesser
+    type: number
+    step: 1
+    min: 10
+    after: cm
+    width: 1/4
+    default: 26
+    when:
+      type: pie
+  diameterMin:
+    label: Durchmesser (min)
+    type: number
+    step: 1
+    after: cm
+    width: 1/4
+    placeholder: 10
+    when:
+      type: pie
+  diameterMax:
+    label: Durchmesser (min)
+    type: number
+    step: 1
+    after: cm
+    max: 40
+    placeholder: 40
+    width: 1/4
+    when:
+      type: pie
+
   ingredients:
     label:
       en: Ingredients

--- a/blueprints/sections/recipe-content.yml
+++ b/blueprints/sections/recipe-content.yml
@@ -27,12 +27,11 @@ fields:
   type:
     label: Rezepttyp
     type: select
-    default: ""
+    default: default
     options:
       default: Standard
       pie: Torte
     width: 1/4
-    required: true
   diameter:
     label: Durchmesser
     type: number

--- a/classes/Models/RecipePage.php
+++ b/classes/Models/RecipePage.php
@@ -90,16 +90,14 @@ class RecipePage extends Page
     {
         $yieldFactor = $this->currentYield() / $this->defaultYield();
 
-        switch ($this->type()->toString()) {
-            case 'pie':
-                $areaDefault = pow($this->defaultDiameter() / 2, 2) * pi();
-                $areaConverted = pow($this->currentDiameter() / 2, 2) * pi();
-                $areaFactor = $areaConverted / $areaDefault;
-                return $yieldFactor * $areaFactor;
-            default:
-                return $yieldFactor;
-                break;
+        if ($this->isType('pie') === true) {
+            $areaDefault = pow($this->defaultDiameter() / 2, 2) * pi();
+            $areaConverted = pow($this->currentDiameter() / 2, 2) * pi();
+            $areaFactor = $areaConverted / $areaDefault;
+            return $yieldFactor * $areaFactor;
         }
+        
+        return $yieldFactor;
     }
 
     public function yieldFormatted(): string

--- a/classes/Models/RecipePage.php
+++ b/classes/Models/RecipePage.php
@@ -41,7 +41,7 @@ class RecipePage extends Page
     {
         if ($this->isType('pie') === true) {
             if ($diameter = (int) get('diameter')) {
-                return min($this->maxDiameter(), max($this->minDiameter(), (int) $diameter));
+                return min($this->maxDiameter(), max($this->minDiameter(), $diameter));
             }
 
             return $this->defaultDiameter();

--- a/classes/Utils/NumberFormatter.php
+++ b/classes/Utils/NumberFormatter.php
@@ -113,6 +113,11 @@ class NumberFormatter
             $amount = round($amount, 0);
         }
 
+        if (in_array($unit, ['EL', 'TL', 'Prise', 'Prisen']) === true) {
+            // No need for decimal for small units
+            $amount = round($amount, 1);
+        }
+
         // Smooth out values
         $floor = floor($amount);
         $decimals = $amount - $floor;

--- a/classes/Utils/NumberFormatter.php
+++ b/classes/Utils/NumberFormatter.php
@@ -108,6 +108,21 @@ class NumberFormatter
             $unit = 'TL';
         }
 
+        if (in_array($unit, ['g', 'ml']) === true) {
+            // No need for decimal for small units
+            $amount = round($amount, 0);
+        }
+
+        // Smooth out values
+        $floor = floor($amount);
+        $decimals = $amount - $floor;
+        foreach([.25, .5, .75, 1] as $frac) {
+            if (abs(($decimals - $frac) / $frac) < .125) {
+                $amount = $floor + $frac;
+                break;
+            }
+        }
+
         // Convert to fraction if enabled in config.
         if ($this->useFractions === true) {
             $fraction = $this->toFraction($amount);
@@ -136,10 +151,13 @@ class NumberFormatter
     {
         if (isset($this->fractionEquivalents[$fraction])) {
             return $this->fractionEquivalents[$fraction];
-        } else if ($parts = explode('/', $fraction) && sizeof($parts) > 0) {
-            return (float) ((int) $parts[0] / (int) $parts[0]);
-        } else {
-            return null;
         }
+        
+        $parts = explode('/', $fraction);
+        if (sizeof($parts) > 0) {
+            return (float) ((int) $parts[0] / (int) $parts[0]);
+        }
+
+        return null;
     }
 }

--- a/snippets/yield.php
+++ b/snippets/yield.php
@@ -1,14 +1,29 @@
 <form class="yield" action="<?= $page->url() ?>" method="GET">
   <input type="number"
-         inputmode="numeric"
-         pattern="[0-9]*"
-         step="1"
-         min="1"
-         name="yield"
-         max="1000"
-         value="<?= $yield ?>"
-         id="yield-input">
+    inputmode="numeric"
+    pattern="[0-9]*"
+    step="1"
+    min="1"
+    name="yield"
+    max="1000"
+    value="<?= $yield ?>"
+    id="yield-input"
+  >
   <label for="yield-input"><?= $unit ?></label>
+  <?php if ($diameter = $page->currentDiameter()): ?>
+    (⌀
+    <input type="number"
+      inputmode="numeric"
+      pattern="[0-9]*"
+      step="1"
+      min="<?= $page->minDiameter() ?>"
+      name="diameter"
+      max="<?= $page->maxDiameter() ?>"
+      value="<?= $diameter ?>"
+      id="diameter-input"
+    >
+    cm
+  <?php endif ?>
   <button type="submit">Aktualisieren</button>
   <?php if ($isDefaultYield): ?>
     <a href="<?= $page->url() ?>">(zurücksetzen)</a>

--- a/snippets/yield.php
+++ b/snippets/yield.php
@@ -22,7 +22,7 @@
       value="<?= $diameter ?>"
       id="diameter-input"
     >
-    cm
+    cm)
   <?php endif ?>
   <button type="submit">Aktualisieren</button>
   <?php if ($isDefaultYield): ?>


### PR DESCRIPTION
This adds the ability to convert pie ingredients by the diameter of the cake-pan used. It also improves the output of the number formatter more aggressively, e.g. `66.89 g` => `67 g`, when the unit is `g` or `ml`. Other amounts are just rounded to their closest quarter (`0.25`, `0.5`, `.75` and `1`), e.g. `0.24 TL` => `0.25 TL`, if the difference between the actual value and the closest quarter is less than `0.125`.