### PR TITLE
fix php 8.2 deprecation warning

### DIFF
--- a/classes/Models/RecipePage.php
+++ b/classes/Models/RecipePage.php
@@ -21,6 +21,8 @@ class RecipePage extends Page
     protected static $cuisinesCache;
     protected $typeCache;
 
+    protected array $cache = [];
+
     public function currentYield(): int
     {
         if ($yield = (int) get('yield')) {


### PR DESCRIPTION
PHP 8.2 throws a deprecation warning when a property is defined dynamically.